### PR TITLE
JiraRestClient updated to version 2.0.0-m25 

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>eu.uqasar.jira.adapter.JiraAdapter</groupId>
   <artifactId>JiraAdapter</artifactId>
-  <version>1.2.1</version>
+  <version>1.2.3</version>
   <build>
     <resources>
       <resource>

--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>JiraAdapter</groupId>
+  <groupId>eu.uqasar.jira.adapter.JiraAdapter</groupId>
   <artifactId>JiraAdapter</artifactId>
-  <version>1.0</version>
+  <version>1.2.1</version>
   <build>
     <resources>
       <resource>
@@ -86,7 +86,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>2.3</version>
+        <version>2.5</version>
       </plugin>
     </plugins>
   </build>
@@ -109,6 +109,24 @@
       </snapshots>
       <id>atlassian-public</id>
       <url>https://m2proxy.atlassian.com/repository/public</url>
+    </repository>
+    <repository>
+      <releases />
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>atb-ext-releases</id>
+      <name>ATB Maven Public RELEASES Repository</name>
+      <url>http://www.atb-bremen.de/artifactory/ext-releases-local/</url>
+    </repository>
+    <repository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots />
+      <id>atb-ext-snapshots</id>
+      <name>ATB Maven Public SNAPSHOT Repository</name>
+      <url>http://www.atb-bremen.de/artifactory/ext-snapshots-local/</url>
     </repository>
   </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,8 @@
         <dependency>
             <!-- JRJC is distributed under the Apache 2.0 license. -->
             <groupId>com.atlassian.jira</groupId>
-            <artifactId>jira-rest-java-client</artifactId>
-            <version>2.0.0-m2</version>
+            <artifactId>jira-rest-java-client-core</artifactId>
+            <version>2.0.0-m25</version>
             <exclusions>
                 <exclusion>
                     <!--
@@ -36,6 +36,10 @@
                     -->
                     <groupId>javax.xml.stream</groupId>
                     <artifactId>stax-api</artifactId>
+                </exclusion>
+                <exclusion>
+                	<artifactId>joda-time</artifactId>
+                	<groupId>joda-time</groupId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1,165 +1,186 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
 
-    <!--JiraAdapter is added to maven repo the JiraAdapter jar
-   mvn install:install-file -Dfile=/home/eleni/IdeaProjects/JiraAdapter/target/JiraAdapter-1.0.jar -DgroupId=JiraAdapter -DartifactId=JiraAdapter -Dversion=1.0 -Dpackaging=jar
-    -->
-    <groupId>JiraAdapter</groupId>
-    <artifactId>JiraAdapter</artifactId>
-    <version>1.2</version>
+	<!--JiraAdapter is added to maven repo the JiraAdapter jar mvn install:install-file 
+		-Dfile=/home/eleni/IdeaProjects/JiraAdapter/target/JiraAdapter-1.0.jar -DgroupId=JiraAdapter 
+		-DartifactId=JiraAdapter -Dversion=1.0 -Dpackaging=jar -->
+	<groupId>eu.uqasar.jira.adapter.JiraAdapter</groupId>
+	<artifactId>JiraAdapter</artifactId>
+	<version>1.2.2</version>
 
+	<dependencies>
+		<!--After adding to maven repo the uQuasarAdapter jar mvn install:install-file 
+			-Dfile=/home/eleni/IdeaProjects/uQasarAdapter/target/uQasarAdapter.jar -DgroupId=uQasarAdapter 
+			-DartifactId=uQasarAdapter -Dversion=1.0 -Dpackaging=jar -->
+		<dependency>
+			<groupId>eu.uqasar.adapter.uQasarAdapter</groupId>
+			<artifactId>uQasarAdapter</artifactId>
+			<version>2.0.4</version>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<!-- JRJC is distributed under the Apache 2.0 license. -->
+			<groupId>com.atlassian.jira</groupId>
+			<artifactId>jira-rest-java-client-core</artifactId>
+			<version>2.0.0-m25</version>
+			<exclusions>
+				<exclusion>
+					<!-- Not excluding this will pull in both stax:stax-api:1.0.1 and javax.xml.stream:stax-api:1.0.2 
+						as transitive dependencies. We don't want both, and not excluding this will 
+						give you a duplicate warning when the dependencies are shaded into the jar 
+						by the maven-shade-plugin -->
+					<groupId>javax.xml.stream</groupId>
+					<artifactId>stax-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<artifactId>joda-time</artifactId>
+					<groupId>joda-time</groupId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<inherited>true</inherited>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>2.5.1</version>
+				<configuration>
+					<source>1.6</source>
+					<target>1.6</target>
+					<encoding>UTF-8</encoding>
+					<showWarnings>true</showWarnings>
+					<showDeprecation>true</showDeprecation>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>2.1</version>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<transformers>
+						<transformer
+							implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+							<mainClass>com.atlassian.jira.examples.Main</mainClass>
+						</transformer>
+					</transformers>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<version>1.2.1</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>java</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<mainClass>eu.uqasar.jira.adapter.JiraAdapter</mainClass>
+				</configuration>
+			</plugin>
+			<plugin>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<configuration>
+					<archive>
+						<manifest>
+							<mainClass>eu.uqasar.jira.adapter.JiraAdapter</mainClass>
+						</manifest>
+					</archive>
+					<descriptorRefs>
+						<descriptorRef>jar-with-dependencies</descriptorRef>
+					</descriptorRefs>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-resources-plugin</artifactId>
+				<version>2.5</version>
+			</plugin>
+		</plugins>
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>true</filtering>
+			</resource>
+		</resources>
 
-    <dependencies>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<version>2.3.2</version>
+					<configuration>
+						<source>1.6</source>
+						<target>1.6</target>
+						<compilerArgument></compilerArgument>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
 
-        <!--After adding to maven repo the uQuasarAdapter jar
-        mvn install:install-file -Dfile=/home/eleni/IdeaProjects/uQasarAdapter/target/uQasarAdapter.jar -DgroupId=uQasarAdapter -DartifactId=uQasarAdapter -Dversion=1.0 -Dpackaging=jar
-        -->
-        <dependency>
-        <groupId>uQasarAdapter</groupId>
-        <artifactId>uQasarAdapter</artifactId>
-        <version>1.0</version>
-        </dependency>
-        <dependency>
-            <!-- JRJC is distributed under the Apache 2.0 license. -->
-            <groupId>com.atlassian.jira</groupId>
-            <artifactId>jira-rest-java-client-core</artifactId>
-            <version>2.0.0-m25</version>
-            <exclusions>
-                <exclusion>
-                    <!--
-                   Not excluding this will pull in both stax:stax-api:1.0.1 and javax.xml.stream:stax-api:1.0.2
-                   as transitive dependencies. We don't want both, and not excluding this will give you a duplicate
-                   warning when the dependencies are shaded into the jar by the maven-shade-plugin
-                    -->
-                    <groupId>javax.xml.stream</groupId>
-                    <artifactId>stax-api</artifactId>
-                </exclusion>
-                <exclusion>
-                	<artifactId>joda-time</artifactId>
-                	<groupId>joda-time</groupId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-    </dependencies>
-    <build>
-    <plugins>
-        <plugin>
-            <inherited>true</inherited>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <version>2.5.1</version>
-            <configuration>
-                <source>1.6</source>
-                <target>1.6</target>
-                <encoding>UTF-8</encoding>
-                <showWarnings>true</showWarnings>
-                <showDeprecation>true</showDeprecation>
-            </configuration>
-        </plugin>
-        <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-shade-plugin</artifactId>
-            <version>2.1</version>
-            <executions>
-                <execution>
-                    <phase>package</phase>
-                    <goals>
-                        <goal>shade</goal>
-                    </goals>
-                </execution>
-            </executions>
-            <configuration>
-                <transformers>
-                    <transformer
-                            implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                        <mainClass>com.atlassian.jira.examples.Main</mainClass>
-                    </transformer>
-                </transformers>
-            </configuration>
-        </plugin>
-        <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>exec-maven-plugin</artifactId>
-            <version>1.2.1</version>
-            <executions>
-                <execution>
-                    <goals>
-                        <goal>java</goal>
-                    </goals>
-                </execution>
-            </executions>
-            <configuration>
-                <mainClass>eu.uqasar.jira.adapter.JiraAdapter</mainClass>
-            </configuration>
-        </plugin>
-        <plugin>
-            <artifactId>maven-assembly-plugin</artifactId>
-            <configuration>
-                <archive>
-                    <manifest>
-                        <mainClass>eu.uqasar.jira.adapter.JiraAdapter</mainClass>
-                    </manifest>
-                </archive>
-                <descriptorRefs>
-                    <descriptorRef>jar-with-dependencies</descriptorRef>
-                </descriptorRefs>
-            </configuration>
-        </plugin>
-        <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-resources-plugin</artifactId>
-            <version>2.3</version>
-        </plugin>
-    </plugins>
-        <resources>
-            <resource>
-                <directory>src/main/resources</directory>
-                <filtering>true</filtering>
-            </resource>
-        </resources>
+	</build>
 
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>2.3.2</version>
-                    <configuration>
-                        <source>1.6</source>
-                        <target>1.6</target>
-                        <compilerArgument></compilerArgument>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
+	<repositories>
+		<repository>
+			<id>Apache Nexus</id>
+			<url>https://repository.apache.org/content/repositories/snapshots/</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+		<repository>
+			<id>atlassian-public</id>
+			<url>https://m2proxy.atlassian.com/repository/public</url>
+			<snapshots>
+				<enabled>true</enabled>
+				<updatePolicy>daily</updatePolicy>
+				<checksumPolicy>warn</checksumPolicy>
+			</snapshots>
+			<releases>
+				<enabled>true</enabled>
+				<checksumPolicy>warn</checksumPolicy>
+			</releases>
+		</repository>
 
-    </build>
-
-    <repositories>
-        <repository>
-            <id>Apache Nexus</id>
-            <url>https://repository.apache.org/content/repositories/snapshots/</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>atlassian-public</id>
-            <url>https://m2proxy.atlassian.com/repository/public</url>
-            <snapshots>
-                <enabled>true</enabled>
-                <updatePolicy>daily</updatePolicy>
-                <checksumPolicy>warn</checksumPolicy>
-            </snapshots>
-            <releases>
-                <enabled>true</enabled>
-                <checksumPolicy>warn</checksumPolicy>
-            </releases>
-        </repository>
-    </repositories>
+		<!-- ATB Maven Repository -->
+		<repository>
+			<id>atb-ext-releases</id>
+			<name>ATB Maven Public RELEASES Repository</name>
+			<url>http://www.atb-bremen.de/artifactory/ext-releases-local/</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+		<repository>
+			<id>atb-ext-snapshots</id>
+			<name>ATB Maven Public SNAPSHOT Repository</name>
+			<url>http://www.atb-bremen.de/artifactory/ext-snapshots-local/</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     -->
     <groupId>JiraAdapter</groupId>
     <artifactId>JiraAdapter</artifactId>
-    <version>1.0</version>
+    <version>1.2</version>
 
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 		-DartifactId=JiraAdapter -Dversion=1.0 -Dpackaging=jar -->
 	<groupId>eu.uqasar.jira.adapter.JiraAdapter</groupId>
 	<artifactId>JiraAdapter</artifactId>
-	<version>1.2.2</version>
+	<version>1.2.3</version>
 
 	<dependencies>
 		<!--After adding to maven repo the uQuasarAdapter jar mvn install:install-file 
@@ -24,7 +24,7 @@
 			<!-- JRJC is distributed under the Apache 2.0 license. -->
 			<groupId>com.atlassian.jira</groupId>
 			<artifactId>jira-rest-java-client-core</artifactId>
-			<version>2.0.0-m25</version>
+			<version>2.0.0</version>
 			<exclusions>
 				<exclusion>
 					<!-- Not excluding this will pull in both stax:stax-api:1.0.1 and javax.xml.stream:stax-api:1.0.2 
@@ -34,11 +34,11 @@
 					<groupId>javax.xml.stream</groupId>
 					<artifactId>stax-api</artifactId>
 				</exclusion>
-				<exclusion>
+<!-- 				<exclusion>
 					<artifactId>joda-time</artifactId>
 					<groupId>joda-time</groupId>
 				</exclusion>
-			</exclusions>
+ -->			</exclusions>
 		</dependency>
 	</dependencies>
 	<build>

--- a/src/main/java/eu/uqasar/jira/adapter/JiraAdapter.java
+++ b/src/main/java/eu/uqasar/jira/adapter/JiraAdapter.java
@@ -1,5 +1,20 @@
 package eu.uqasar.jira.adapter;
 
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.codehaus.jettison.json.JSONArray;
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
+
 import com.atlassian.jira.rest.client.api.JiraRestClient;
 import com.atlassian.jira.rest.client.api.JiraRestClientFactory;
 import com.atlassian.jira.rest.client.api.domain.BasicIssue;
@@ -8,6 +23,8 @@ import com.atlassian.jira.rest.client.api.domain.Issue;
 import com.atlassian.jira.rest.client.api.domain.SearchResult;
 import com.atlassian.jira.rest.client.internal.async.AsynchronousJiraRestClientFactory;
 import com.atlassian.util.concurrent.Promise;
+import com.google.common.collect.Iterables;
+
 import eu.uqasar.adapter.SystemAdapter;
 import eu.uqasar.adapter.exception.uQasarException;
 import eu.uqasar.adapter.model.BindedSystem;
@@ -15,15 +32,6 @@ import eu.uqasar.adapter.model.Measurement;
 import eu.uqasar.adapter.model.User;
 import eu.uqasar.adapter.model.uQasarMetric;
 import eu.uqasar.adapter.query.QueryExpression;
-import org.codehaus.jettison.json.JSONArray;
-import org.codehaus.jettison.json.JSONException;
-import org.codehaus.jettison.json.JSONObject;
-
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.LinkedList;
-import java.util.List;
 
 /**
  * Created with IntelliJ IDEA.
@@ -35,9 +43,12 @@ import java.util.List;
 public class JiraAdapter implements SystemAdapter {
 
 
-
+	// Define a sample value for max results to be fetched
+	private final int MAX_RESULTS = 1000; 
+	private final static Logger LOGGER = Logger.getLogger(JiraAdapter.class.getName());
 
     public JiraAdapter() {
+    	LOGGER.setLevel(Level.INFO);
     }
 
     @Override
@@ -73,33 +84,57 @@ public class JiraAdapter implements SystemAdapter {
 
             }   else if (queryExpression.getQuery().equalsIgnoreCase(uQasarMetric.ISSUES_PER_PROJECTS_PER_SYSTEM_INSTANCE.name())) {
 
-                Promise<SearchResult> searchResultPromise = client.getSearchClient().searchJql(" ORDER BY project DESC");
-                Iterable<Issue> issues =  searchResultPromise.claim().getIssues();
+            	LOGGER.info("Fetching data for metric " +uQasarMetric.ISSUES_PER_PROJECTS_PER_SYSTEM_INSTANCE.name());            	
+                
+            	List<Iterable<Issue> > issues = new ArrayList<Iterable<Issue>>();
+            	String query = " ORDER BY project DESC";
+            	issues = getIssues(client, query);
+            	
+                // Add all the issues to the measurements
                 measurements.add(new Measurement(uQasarMetric.ISSUES_PER_PROJECTS_PER_SYSTEM_INSTANCE,formatIssuesResult(issues)));
 
             }  else if (queryExpression.getQuery().contains(uQasarMetric.FIXED_ISSUES_PER_PROJECT.name())) {
 
-                Promise<SearchResult> searchResultPromise = client.getSearchClient().searchJql("resolution = Fixed ORDER BY updatedDate DESC");
-                Iterable<Issue> issues =  searchResultPromise.claim().getIssues();
+            	LOGGER.info("Fetching data for metric " +uQasarMetric.FIXED_ISSUES_PER_PROJECT.name());
+
+                List<Iterable<Issue> > issues = new ArrayList<Iterable<Issue>>();
+            	String query = "resolution = Fixed ORDER BY updatedDate DESC";
+            	issues = getIssues(client, query);
+
                 measurements.add(new Measurement(uQasarMetric.FIXED_ISSUES_PER_PROJECT, formatIssuesResult(issues)));
 
             }  else if (queryExpression.getQuery().contains(uQasarMetric.UNRESOLVED_ISSUES_PER_PROJECT.name())) {
-                Promise<SearchResult> searchResultPromise = client.getSearchClient().searchJql("resolution = Unresolved ORDER BY updatedDate DESC");
-                Iterable<Issue> issues =  searchResultPromise.claim().getIssues();
-                measurements.add(new Measurement(uQasarMetric.UNRESOLVED_ISSUES_PER_PROJECT, formatIssuesResult(issues)));
+
+            	LOGGER.info("Fetching data for metric " +uQasarMetric.UNRESOLVED_ISSUES_PER_PROJECT.name());
+
+                List<Iterable<Issue> > issues = new ArrayList<Iterable<Issue>>();
+            	String query = "resolution = Unresolved ORDER BY updatedDate DESC";
+            	issues = getIssues(client, query);
+
+            	measurements.add(new Measurement(uQasarMetric.UNRESOLVED_ISSUES_PER_PROJECT, formatIssuesResult(issues)));
 
             } else if (queryExpression.getQuery().contains(uQasarMetric.UNRESOLVED_BUG_ISSUES_PER_PROJECT.name())) {
 
-                Promise<SearchResult> searchResultPromise = client.getSearchClient().searchJql("issuetype = Bug AND status = \"To Do\"");
-                Iterable<Issue> issues =  searchResultPromise.claim().getIssues();
+            	LOGGER.info("Fetching data for metric " +uQasarMetric.UNRESOLVED_BUG_ISSUES_PER_PROJECT.name());
+
+                List<Iterable<Issue> > issues = new ArrayList<Iterable<Issue>>();
+            	String query = "issuetype = Bug AND status = \"To Do\"";
+            	issues = getIssues(client, query);
 
                 measurements.add(new Measurement(uQasarMetric.UNRESOLVED_BUG_ISSUES_PER_PROJECT, formatIssuesResult(issues)));
+                
             } else if (queryExpression.getQuery().contains(uQasarMetric.UNRESOLVED_TASK_ISSUES_PER_PROJECT.name())) {
-                Promise<SearchResult> searchResultPromise = client.getSearchClient().searchJql("issuetype = Task AND status = \"To Do\"");
-                Iterable<Issue> issues =  searchResultPromise.claim().getIssues();
+            	
+            	LOGGER.info("Fetching data for metric " +uQasarMetric.UNRESOLVED_TASK_ISSUES_PER_PROJECT.name());
+
+                List<Iterable<Issue> > issues = new ArrayList<Iterable<Issue>>();
+            	String query = "issuetype = Task AND status = \"To Do\"";
+            	issues = getIssues(client, query);
+            	
                 measurements.add(new Measurement(uQasarMetric.UNRESOLVED_TASK_ISSUES_PER_PROJECT, formatIssuesResult(issues)));
+                
             } else {
-            throw new uQasarException(uQasarException.UQasarExceptionType.UQASAR_NOT_EXISTING_METRIC,queryExpression.getQuery());
+            	throw new uQasarException(uQasarException.UQasarExceptionType.UQASAR_NOT_EXISTING_METRIC,queryExpression.getQuery());
             }
 
             // Close the JiraRestClient
@@ -109,7 +144,7 @@ public class JiraAdapter implements SystemAdapter {
 
 
         } catch (JSONException e) {
-            e.printStackTrace();  //To change body of catch statement use File | Settings | File Templates.
+            e.printStackTrace(); 
         } catch (URISyntaxException e) {
             throw new uQasarException(uQasarException.UQasarExceptionType.BINDING_SYSTEM_BAD_URI_SYNTAX,bindedSystem,e.getCause());
         }  catch (RuntimeException e){
@@ -155,20 +190,95 @@ public class JiraAdapter implements SystemAdapter {
         }
     }
 
-    public String formatIssuesResult( Iterable<Issue> issues) throws JSONException {
+
+    /**
+     * Get a list of Iterable Issues based on a query 
+     * @param client
+     * @param query
+     * @return
+     */
+    public List<Iterable<Issue> > getIssues(JiraRestClient client, String query) {
+
+    	// List that will contain the results
+        List<Iterable<Issue> > allIssues = new ArrayList<Iterable<Issue>>();
+
+    	HashSet<String> fields = new HashSet<String>();
+    	fields.add("*all");
+    	
+    	// Start fetching the results from index 0
+    	Integer startIdx = 0;
+        Promise<SearchResult> searchResultPromise = client.getSearchClient().searchJql(query, new Integer(MAX_RESULTS), startIdx, fields); 
+        
+        // How many issues there are in total?
+        int totalIssues = searchResultPromise.claim().getTotal();
+    	LOGGER.info("Total issues: " +totalIssues);
+        
+        // Get the actual issues 
+        Iterable<Issue> issues =  searchResultPromise.claim().getIssues();
+        allIssues.add(issues);
+        
+        // Get the number of the issues
+        int nrOfObtained = getSizeValues(issues);                
+        LOGGER.info("Obtained issues: " +nrOfObtained);
+        
+        // If there are more issues continue from the next index that has not yet been obtained
+        while (nrOfObtained < totalIssues) {
+        	LOGGER.info("Total number of issues is higher than has been fetched. Proceeding to the next start index...");
+        	startIdx += MAX_RESULTS;
+        	LOGGER.info("New start index: " +startIdx);
+            // New search; fetch results from the following index
+        	searchResultPromise = client.getSearchClient().searchJql(query, new Integer(MAX_RESULTS), startIdx, fields);
+            // Get the actual issues and concatenate to the previous ones
+            Iterable<Issue> furtherIssues = searchResultPromise.claim().getIssues();
+            nrOfObtained += getSizeValues(furtherIssues);
+            LOGGER.info("Obtained issues: " +nrOfObtained);
+            allIssues.add(furtherIssues);
+        }
+
+    	
+    	return allIssues;
+
+    }
+    
+    
+    /**
+     * Create a String containing the JSON with issues. 
+     * This should be optimized for performance, and also enhanced to fetch the content pointed by the URL
+     * to prevent calls in the U-QASAR platform. 
+     * @param listOfIssues
+     * @return
+     * @throws JSONException
+     */
+    public String formatIssuesResult( List<Iterable<Issue> > listOfIssues) throws JSONException {
 
         JSONArray measurementResultJSONArray = new JSONArray();
 
-        for (BasicIssue issue : issues) {
-            JSONObject i = new JSONObject();
-            i.put("self", issue.getSelf());
-            i.put("key", issue.getKey());
-            measurementResultJSONArray.put(i);
-        }
-
+        for (Iterable<Issue> iterableIssue : listOfIssues) {
+            for (BasicIssue issue : iterableIssue) {
+                JSONObject i = new JSONObject();
+                i.put("self", issue.getSelf());
+                i.put("key", issue.getKey());
+                measurementResultJSONArray.put(i);
+            }
+		}
+        
         return  measurementResultJSONArray.toString();
     }
 
+    
+    /**
+     * Returns the size of the iterable
+     * @param values
+     * @return
+     */
+    private int getSizeValues(Iterable<?> values) {
+
+        if (values instanceof Collection<?>) {
+        	 return ((Collection<?>)values).size();
+        }
+        
+        return 0;
+    }
 
 
     //in order to invoke main from outside jar


### PR DESCRIPTION
I have updated the JiraRestClient by Atlassian to a more fresh version due to an issue that the opened HTTP connections remained open and as the resources aren't freed, the server runs out of resources eventually. The changed code uses a newer JAR of the library and contains the method close() for closing the client connections.
